### PR TITLE
Add `CLAUDE.md` with project guidelines and improve video recording t…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+RushRanks is a React Native 0.79 mobile app (iOS + Android) for video ranking/streaming social media. Built with TypeScript, React 19, and the React Native CLI (not Expo).
+
+## Commands
+
+```bash
+# Start Metro dev server
+npm start
+
+# Build and run
+npm run ios
+npm run android
+npm run release:android    # Production Android build
+
+# Code quality
+npm run lint               # ESLint
+npm run test               # Jest
+
+# iOS native deps (after cloning or updating native deps)
+bundle install             # First time only - install CocoaPods
+cd ios && RCT_NEW_ARCH_ENABLED=1 bundle exec pod install && cd ..
+```
+
+**Node version**: v22.13.1 (see `.nvmrc`), minimum v18.
+
+## Architecture
+
+### Navigation (`src/navigation/`)
+Two-stack conditional navigation based on auth state:
+- **AuthNavigator**: Login, SignUp, ForgotPassword, VerifyEmail, Eula
+- **AppNavigator**: Authenticated app with bottom tabs + stack screens
+- **TabsNavigator**: 4 bottom tabs — TabMain, TabGlobalVideo, TabForYou, TabProfile
+- Screen names and type-safe params are defined in `src/navigation/screens.ts`
+- `navigationRef.ts` provides imperative navigation outside React components
+
+### State Management (Zustand + React Query)
+- **Zustand stores** in `src/state/` with AsyncStorage persistence via `src/lib/createPersistStore.ts`
+  - `authStore` — user auth, JWT token, profile, push token
+  - `uiStore` — menu visibility, selected US state filter
+- **TanStack React Query v5** for server state, configured in `src/lib/api.ts`
+  - Query cache persisted to AsyncStorage
+  - 24-hour garbage collection time
+
+### API Layer (`src/lib/api.ts`)
+- Axios instance with base URL from `react-native-config` (`APP_API_URL` in `.env`)
+- Request interceptor auto-injects JWT Bearer token from authStore
+- Response interceptor handles 401 errors with silent logout and store cache clearing
+- Custom headers: `X-Client: ReelApp`, `x-Client-Version`
+
+### Styling
+- **NativeWind v4** (Tailwind CSS for React Native) with `tailwind.config.js`
+- Global styles in `global.css`
+- Custom dark theme colors in `src/theme/colors.ts`
+- Prettier sorts Tailwind classes via `prettier-plugin-tailwindcss`
+
+### Key Source Directories
+- `src/components/` — reusable UI (video feed, chat, user components, bottom sheets)
+- `src/screens/` — full-screen page components organized by feature (auth, home, user, video, chat)
+- `src/hooks/` — custom hooks (push notifications, etc.)
+- `src/lib/` — core utilities (API client, store persistence, NativeWind interops)
+- `src/state/` — Zustand stores and types
+
+### Video & Media Stack
+- `react-native-video` for playback
+- `react-native-vision-camera` for recording
+- `@react-native-camera-roll/camera-roll` for gallery access
+- `react-native-create-thumbnail` for video thumbnails
+
+### Forms
+- `react-hook-form` with `zod` v4 validation via `@hookform/resolvers`
+
+## Code Style
+
+- TypeScript strict mode, extending `@react-native/typescript-config`
+- Platform-specific files via module suffixes: `.ios.ts`, `.android.ts`, `.native.ts`
+- ESLint extends `@react-native`
+- Prettier: single quotes, semicolons, 100 char width, trailing commas, 2-space tabs
+- Functional components with hooks only (no class components)
+
+## Environment Setup
+
+Copy `.env.example` to `.env` and set `APP_API_URL`. The app reads env vars via `react-native-config`.

--- a/src/components/videoRecording/VideoRecording.tsx
+++ b/src/components/videoRecording/VideoRecording.tsx
@@ -132,7 +132,10 @@ export const VideoRecording = () => {
     });
   });
 
-  const handleStartRecording = async () => {
+  const isStoppingRef = useRef(false);
+
+  const handleStartRecording = useCallback(async () => {
+    isStoppingRef.current = false;
     setIsRecording(true);
 
     if (isIOS) {
@@ -154,9 +157,13 @@ export const VideoRecording = () => {
         console.log('[onRecordingError]', error);
       },
     });
-  };
+  }, [setPreviewUri]);
 
-  const handleFinishRecording = async () => {
+  const handleFinishRecording = useCallback(async () => {
+    if (isStoppingRef.current) {
+      return;
+    }
+    isStoppingRef.current = true;
     console.log('STOP RECORDING...');
     try {
       await cameraRef.current?.stopRecording();
@@ -169,8 +176,10 @@ export const VideoRecording = () => {
       setIsRecording(false);
     } catch (error) {
       Alert.alert((error as Error)?.message || 'Unable to stop video record: unknown error');
+    } finally {
+      isStoppingRef.current = false;
     }
-  };
+  }, []);
 
   const handleCloseCamera = () => {
     clear();

--- a/src/components/videoRecording/controls/Timer.tsx
+++ b/src/components/videoRecording/controls/Timer.tsx
@@ -13,7 +13,10 @@ export interface TimerProps {
 export const Timer = ({ active, onTimeOut, maxDurationSeconds }: TimerProps) => {
   const [secondsLeft, setSecondsLeft] = useState<number>(maxDurationSeconds);
   const timerRef = useRef<NodeJS.Timeout>(null);
+  const onTimeOutRef = useRef(onTimeOut);
   const opacity = useSharedValue(0);
+
+  onTimeOutRef.current = onTimeOut;
 
   useEffect(() => {
     if (active) {
@@ -24,7 +27,7 @@ export const Timer = ({ active, onTimeOut, maxDurationSeconds }: TimerProps) => 
         tickValue--;
         if (tickValue <= 0) {
           clearInterval(timerRef.current!);
-          onTimeOut();
+          onTimeOutRef.current();
         }
       }, 1000);
     } else {
@@ -35,7 +38,7 @@ export const Timer = ({ active, onTimeOut, maxDurationSeconds }: TimerProps) => 
     return () => {
       clearInterval(timerRef.current!);
     };
-  }, [active, onTimeOut, maxDurationSeconds, opacity]);
+  }, [active, maxDurationSeconds, opacity]);
 
   const styles = useAnimatedStyle(() => ({
     opacity: opacity.value,


### PR DESCRIPTION
  Root cause

  handleFinishRecording (which calls stopRecording()) could be invoked twice concurrently — once from the Timer timeout and once from the RecordButton gesture release. Since setIsRecording(false) only runs after the async stopRecording()
  completes, the second call would slip through before state updated. On iPhone 17 (faster hardware / iOS 26), the race window is tighter, making VisionCamera's internal guard throw the error.

  Changes

  VideoRecording.tsx (src/components/videoRecording/VideoRecording.tsx):
  - Added isStoppingRef — a synchronous ref guard that prevents stopRecording() from being called twice. Set to true immediately on entry, reset in finally.
  - handleStartRecording resets isStoppingRef to false so the next recording cycle works cleanly.
  - Both handlers wrapped in useCallback to stabilize their references.

  Timer.tsx (src/components/videoRecording/controls/Timer.tsx):
  - Stored onTimeOut in a ref (onTimeOutRef) and removed it from the useEffect dependency array. Previously, every parent re-render created a new onTimeOut function, causing the effect to re-run and reset the interval mid-countdown. This
  could cause erratic timer behavior and additional race conditions.