### PR TITLE
Add `activatePlaybackAudioSession` method and handle playback error i…

### DIFF
--- a/ios/RushRanks/CustomAudioSessionManager.swift
+++ b/ios/RushRanks/CustomAudioSessionManager.swift
@@ -38,6 +38,22 @@ class CustomAudioSessionManager: NSObject {
   // }
   
   @objc
+  func activatePlaybackAudioSession() {
+    do {
+      let session = AVAudioSession.sharedInstance()
+      try session.setCategory(
+        .playback,
+        mode: .moviePlayback,
+        options: [.allowBluetooth, .allowAirPlay]
+      )
+      try session.setActive(true)
+      print("✅ [CustomAudioSessionManager] Audio session activated for playback")
+    } catch {
+      print("❌ [CustomAudioSessionManager] Failed to activate playback session: \(error)")
+    }
+  }
+
+  @objc
   func deactivateAudioSession() {
     do {
       try AVAudioSession.sharedInstance().setActive(false)

--- a/ios/RushRanks/CustomAudioSessionManagerBridge.m
+++ b/ios/RushRanks/CustomAudioSessionManagerBridge.m
@@ -3,6 +3,7 @@
 @interface RCT_EXTERN_MODULE(CustomAudioSessionManager, NSObject)
 
 RCT_EXTERN_METHOD(activateVideoRecordingAudioSession)
+RCT_EXTERN_METHOD(activatePlaybackAudioSession)
 RCT_EXTERN_METHOD(deactivateAudioSession)
 
 @end

--- a/src/components/videoRecording/VideoPreview.tsx
+++ b/src/components/videoRecording/VideoPreview.tsx
@@ -93,6 +93,7 @@ export const VideoPreview = () => {
         disableAudioSessionManagement
         repeat
         onLoad={() => actions.setIsPreviewReady(true)}
+        onError={(error) => console.error('[VideoPreview] Playback error:', error)}
       />
       {!uploading && <VideoDescriptionInput value={description} setValue={setDescription} />}
       <View

--- a/src/components/videoRecording/VideoRecording.tsx
+++ b/src/components/videoRecording/VideoRecording.tsx
@@ -148,7 +148,7 @@ export const VideoRecording = () => {
     cameraRef.current?.startRecording({
       onRecordingFinished: async (video) => {
         if (isIOS) {
-          await CustomAudioSessionManager.activateVideoRecordingAudioSession();
+          await CustomAudioSessionManager.activatePlaybackAudioSession();
         }
         console.log('[onRecordingFinished]', video);
         setPreviewUri(video.path);


### PR DESCRIPTION
All changes are in place. The SourceKit diagnostics about "unavailable in macOS" are expected — AVAudioSession is an iOS-only API, and this code only runs on iOS devices.

  Here's a summary of the four changes made:

  1. ios/RushRanks/CustomAudioSessionManager.swift — Added activatePlaybackAudioSession() method (lines 40-54) that sets the audio session to .playback category with .moviePlayback mode, which is the correct configuration for video
  playback (vs .playAndRecord + .videoRecording used during recording).
  2. ios/RushRanks/CustomAudioSessionManagerBridge.m — Exported activatePlaybackAudioSession via the React Native bridge (line 6).
  3. src/components/videoRecording/VideoRecording.tsx — Changed the onRecordingFinished callback (line 151) to call activatePlaybackAudioSession() instead of activateVideoRecordingAudioSession(), so the audio session is correctly
  configured for playback when transitioning to the preview screen.
  4. src/components/videoRecording/VideoPreview.tsx — Added onError handler (line 96) to the <Video> component so playback failures are logged instead of being silently swallowed.

  To test, rebuild the iOS app (npm run ios) and verify that recorded videos play in the preview screen on both iPhone 17 and older devices.