### PR TITLE
Improve video recording error handling and ensure proper track finali…

### DIFF
--- a/patches/react-native-vision-camera+4.7.3.patch
+++ b/patches/react-native-vision-camera+4.7.3.patch
@@ -35,3 +35,46 @@ index 8e57710..146096b 100644
          }
          recordingSession.stop()
          return nil
+diff --git a/node_modules/react-native-vision-camera/ios/Core/Recording/Track.swift b/node_modules/react-native-vision-camera/ios/Core/Recording/Track.swift
+index 8dec5ce..1cc2263 100644
+--- a/node_modules/react-native-vision-camera/ios/Core/Recording/Track.swift
++++ b/node_modules/react-native-vision-camera/ios/Core/Recording/Track.swift
+@@ -84,6 +84,18 @@ final class Track {
+     timeline.resume()
+   }
+ 
++  /**
++   Force-marks the track input as finished if it hasn't already been naturally finished
++   through the timeline. This is needed on devices (e.g. iPhone 17) where the camera
++   hardware stops delivering frames immediately after stop(), so no "late" frame arrives
++   to trigger the natural finish flow via TrackTimeline.
++   */
++  func ensureFinished() {
++    guard !timeline.isFinished else { return }
++    VisionLogger.log(level: .info, message: "Force-finishing \(type) track input (no late frames arrived after stop).")
++    assetWriterInput.markAsFinished()
++  }
++
+   func append(buffer originalBuffer: CMSampleBuffer) throws {
+     // 1. If the track is already finished (from a previous call), don't write anything.
+     if timeline.isFinished {
+diff --git a/node_modules/react-native-vision-camera/ios/Core/RecordingSession.swift b/node_modules/react-native-vision-camera/ios/Core/RecordingSession.swift
+index adee189..d015490 100644
+--- a/node_modules/react-native-vision-camera/ios/Core/RecordingSession.swift
++++ b/node_modules/react-native-vision-camera/ios/Core/RecordingSession.swift
+@@ -308,6 +308,15 @@ final class RecordingSession {
+     // If there are audio frames after this timestamp, they will be cut off.
+     assetWriter.endSession(atSourceTime: lastVideoTimestamp)
+     VisionLogger.log(level: .info, message: "Asset Writer session stopped at \(lastVideoTimestamp.seconds).")
++
++    // Ensure all track inputs are marked as finished before calling finishWriting.
++    // On some devices (e.g. iPhone 17), the camera hardware stops delivering frames
++    // immediately after stop(), so no "late" frame arrives to trigger Track's natural
++    // markAsFinished() flow via the timeline. Without this, finishWriting() would hang
++    // indefinitely waiting for inputs to be marked as finished.
++    videoTrack?.ensureFinished()
++    audioTrack?.ensureFinished()
++
+     assetWriter.finishWriting {
+       VisionLogger.log(level: .info, message: "Asset Writer finished writing!")
+       self.completionHandler(self, self.assetWriter.status, self.assetWriter.error)

--- a/src/components/videoRecording/VideoRecording.tsx
+++ b/src/components/videoRecording/VideoRecording.tsx
@@ -157,6 +157,7 @@ export const VideoRecording = () => {
       },
       onRecordingError: (error) => {
         console.log('[onRecordingError]', error);
+        Alert.alert('Recording Error', error?.message || 'Unknown recording error');
       },
     });
   }, [setPreviewUri]);


### PR DESCRIPTION
 Root cause

  On iPhone 17, the camera hardware stops delivering video/audio buffers immediately when recording stops. VisionCamera's Track only marks its AVAssetWriterInput as finished when a "late" frame (a buffer with timestamp after the stop
  event) arrives. Since no late frames arrive on iPhone 17:

  1. assetWriterInput.markAsFinished() is never called
  2. AVAssetWriter.finishWriting() hangs indefinitely waiting for inputs to be finalized
  3. The completion handler never fires
  4. Neither onRecordingFinished nor onRecordingError reaches JavaScript
  5. previewUri is never set → preview screen never shows

  On older iPhones (13, 14, 16), the camera pipeline has natural latency — a few extra frames trickle in after stop, triggering the normal finish flow.

  The fix (patch file)

  patches/react-native-vision-camera+4.7.3.patch — two new changes added:

  1. Track.swift — Added ensureFinished() method that force-marks the AVAssetWriterInput as finished if the timeline hasn't naturally finished (no late frames arrived)
  2. RecordingSession.swift — In finish(), calls videoTrack?.ensureFinished() and audioTrack?.ensureFinished() right before assetWriter.finishWriting(), ensuring all inputs are properly marked before the writer attempts to finalize

  Supporting JS changes

  3. VideoRecording.tsx — onRecordingError now shows an Alert (visible on real devices without console)
  4. VideoPreview.tsx — file:// prefix on video URI, removed disableAudioSessionManagement (camera is unmounted during preview), visible Alert on playback error

  To test

  Rebuild the iOS app (npm run ios or archive for device), then on iPhone 17: record a video, press stop, verify the preview appears and plays. Also verify on an older iPhone that nothing regressed.